### PR TITLE
Made site more responsive for smaller viewports

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,7 +36,7 @@
       </div>
     </nav>
 
-    <div class="wrapper">
+    <div class="container">
       <header>
         <p><b>Women Who Code DC (WWCDC)</b> is the DC Network for <b>Women Who Code (WWC)</b> which is a global non-profit dedicated to inspiring women to excel in technology careers. We provide an avenue into tech, empower women with skills needed for professional advancement, and provide environments where networking and mentorship are valued. The organization has executed more than 1,200 free events around the world, garnered a membership exceeding 20,000, and has a presence in 15 countries.</h3><p></p>
         <p>If interested in partnering with us or learning more about what we do, please reach out to <a href="mailto:WWCodeDC@gmail.com">WWCodeDC@gmail.com</a>.</p>
@@ -70,7 +70,10 @@
              </ul>
           </div>
         </section>
-      <footer>
+    </div>
+
+    <footer class="footer">
+      <div class="container">
         <p class="view">
           <a href="http://www.meetup.com/Women-Who-Code-DC/">Our Meetup Group</a><br />
           <a href="https://github.com/womenwhocodedc">Our GitHub Profile</a><br />
@@ -78,9 +81,9 @@
           <a href="https://twitter.com/WomenWhoCodeDC" class="twitter-follow-button" data-show-count="false">Follow @WomenWhoCodeDC</a>
           <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
         </p>
-      </footer>
-      </footer>
-    </div>
+      </div>
+    </footer>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.js"></script>
     <script src="assets/javascripts/scale.fix.js"></script>
   </body>

--- a/assets/stylesheets/styles.css
+++ b/assets/stylesheets/styles.css
@@ -1,12 +1,18 @@
 @import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
 @import url(http://fonts.googleapis.com/css?family=Ubuntu);
 
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 body {
-  padding-top: 100px;
+  padding-top: 100px; /* Padding for fixed top-nav */
   font-family: 'Ubuntu', serif;
   font-size: 16px;
   color:#777;
   font-weight:300;
+  margin-bottom: 110px;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -51,7 +57,7 @@ a small {
   display:block;
 }
 
-.wrapper {
+.container {
   width:860px;
   margin:0 auto;
 }
@@ -104,7 +110,6 @@ img {
 header {
   width:270px;
   float:left;
-  position:fixed;
 }
 
 header ul {
@@ -168,7 +173,6 @@ header ul a strong {
 section.section-right {
   width:500px;
   float:right;
-  padding-bottom:50px;
 }
 
 small {
@@ -183,27 +187,24 @@ hr {
 }
 
 footer {
-  width:270px;
-  float:left;
-  position:fixed;
-  bottom:20px;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  /* Fixed height of footer */
+  height: 110px;
 }
 
 @media print, screen and (max-width: 960px) {
-  
-  div.wrapper {
+
+  div.container {
     width:auto;
     margin:0;
   }
   
-  header, section, footer {
+  header, section {
     float:none;
     position:static;
     width:auto;
-  }
-  
-  header {
-    padding-right:320px;
   }
   
   section {
@@ -211,6 +212,10 @@ footer {
     border-width:1px 0;
     padding:20px 0;
     margin:0 0 20px;
+  }
+
+  section.section-right {
+    float: none;
   }
   
   header a small {
@@ -245,6 +250,7 @@ footer {
 @media print, screen and (max-width: 480px) {
   body {
     padding:15px;
+    padding-top: 75px; /* Padding for fixed top-nav */
   }
   
   header ul {

--- a/index.html
+++ b/index.html
@@ -36,11 +36,11 @@
       </div>
     </nav>
 
-    <div class="wrapper">
+    <div class="container">
       <header>
         <h1>Women Who Code DC</h1>
         <p>Our chapter is focused on providing women with tangible programming skills to expand their career opportunities.</p>
-        <p>We are made up of a lot of study groups that learn anything in the "full stack" of development (aka from the very back end of coding involving networks and security, to the front end involving scripting and styling). Whether you love Python or are trying to learn anything you can - we are a group that allows you to pick and choose whatever fits your learning style!.</p>
+        <p>We are made up of a lot of study groups that learn anything in the "full stack" of development (aka from the very back end of coding involving networks and security, to the front end involving scripting and styling). Whether you love Python or are trying to learn anything you can - we are a group that allows you to pick and choose whatever fits your learning style!</p>
       </header>
       <section class="section-right">
 
@@ -61,7 +61,10 @@
         <p><a href="http://nupurkapoor.github.io/js-study-group/#/">Presentation slides</a>.</p>
       
       </section>
-      <footer>
+    </div>
+    
+    <footer>
+      <div class="container">
         <p class="view">
           <a href="http://www.meetup.com/Women-Who-Code-DC/">Our Meetup Group</a><br />
           <a href="https://github.com/womenwhocodedc">Our GitHub Profile</a><br />
@@ -69,8 +72,9 @@
           <a href="https://twitter.com/WomenWhoCodeDC" class="twitter-follow-button" data-show-count="false">Follow @WomenWhoCodeDC</a>
           <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
         </p>
-      </footer>
-    </div>
+      </div>
+    </footer>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.js"></script>
     <script src="assets/javascripts/scale.fix.js"></script>
   </body>

--- a/projects/index.html
+++ b/projects/index.html
@@ -35,11 +35,14 @@
         </div><!--/.nav-collapse -->
       </div>
     </nav>
-    <div class="wrapper ">
+    <div class="container">
       <section class="main-content">
         <div id="ghAPIData" class="clearfix"></div>
       </section>
-      <footer>
+    </div>
+
+    <footer>
+      <div class="container">
         <p class="view">
           <a href="http://www.meetup.com/Women-Who-Code-DC/">Our Meetup Group</a><br />
           <a href="https://github.com/womenwhocodedc">Our GitHub Profile</a><br />
@@ -47,8 +50,9 @@
           <a href="https://twitter.com/WomenWhoCodeDC" class="twitter-follow-button" data-show-count="false">Follow @WomenWhoCodeDC</a>
           <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
         </p>
-      </footer>
-    </div>
+      </div>
+    </footer>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.js"></script>
     <script src="../assets/javascripts/scale.fix.js"></script>
     <script src="../assets/javascripts/main.js"></script>


### PR DESCRIPTION
Hi, WWCDC Leads!

I noticed the website had some overlapping text in the footer, and I took a shot at fixing it. On desktop, you'd only notice it if the height of the browser window is smaller than full-size; the footer links ("Our Meetup Group", "Our GitHub Profile", etc.) are displayed on top of the text on the left side. I ended up making a few tweaks, and it looks like now the page handles smaller window sizes a bit better. 

Take a look and let me know what you think. 

P.S. I noticed some of the content hasn't been updated in awhile (it doesn't list all the awesome study groups you guys offer now and only has Ruby and JS)... I'd be happy to update the copy and maybe even add a [Meetup widget](http://www.meetup.com/meetup_api/foundry/) if no one else is working on the website? Let me know!! :)
